### PR TITLE
feat: Require root privileges for upgrade script

### DIFF
--- a/upgrade_ollama.sh
+++ b/upgrade_ollama.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Error: This script must be run as root. Please use sudo." >&2
+  exit 1
+fi
+
 # Ollama Upgrade Script
 # This script upgrades Ollama while preserving your custom service configuration
 


### PR DESCRIPTION
The `upgrade_ollama.sh` script now includes a check at the beginning to ensure it is executed with root privileges.

If you run the script without root (e.g., without `sudo`), it will print an error message to standard error and exit with a status code of 1. This prevents the script from failing at later stages due to insufficient permissions for tasks like managing services or writing to system directories.